### PR TITLE
remove CSS transitions in Chrome 26 on Mac

### DIFF
--- a/app/popup.js
+++ b/app/popup.js
@@ -1,3 +1,9 @@
+// css transitions are broken in chrome 26 on mac
+// add css overrides if appropriate
+if (navigator.appVersion.indexOf("Mac") != -1 && navigator.appVersion.indexOf("Chrome/26") != -1) {
+    document.write('<link rel="stylesheet" href="static/css/osxstyle.css" />');
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     
     window.tvDB = new tvDB();

--- a/static/css/osxstyle.css
+++ b/static/css/osxstyle.css
@@ -1,0 +1,15 @@
+body>div:target
+{
+  -webkit-transition:none !important;
+}
+
+body>div:not(:target)
+{
+  -webkit-transition:none !important;
+}
+
+
+#favorites li strong
+{
+  -webkit-transition:none !important;
+}


### PR DESCRIPTION
CSS transitions are broken on Chrome 26 on Mac. Detect browser and override styles to remove transitions, mentioned in SchizoDuckie/seriesguide-chrome#11

I've added a check for mac and specifically version 26 in the hopes that it will get fixed by 27 and the plugin won't need editing again just to re-enable the transitions.
