### PR TITLE
Fix seriesList.js loading on case sensitive filesystems

### DIFF
--- a/tab.html
+++ b/tab.html
@@ -66,7 +66,7 @@
   <script src="./js/directives/lazyBackground.js"></script>
   <script src="./js/directives/serieDetails.js"></script>
   <script src="./js/directives/serieheader.js"></script>
-  <script src="./js/directives/serieslist.js"></script>
+  <script src="./js/directives/seriesList.js"></script>
   <script src="./js/directives/torrentDialog.js"></script>
   <script src="./js/services/ChromeCast.js"></script>
   <script src="./js/services/DuckieTorrent.js"></script>


### PR DESCRIPTION
Otherwise the plugin is unusable.
