### PR TITLE
Fixed episodes disappearing if torrenting disabled.

### DIFF
--- a/templates/event.html
+++ b/templates/event.html
@@ -3,7 +3,7 @@
 	  <div ng-if="$root.getSetting('torrenting.enabled') && event.episode.values.magnetHash" tooltip="{{ event.episode.getFormattedEpisode() }}">
 	   	 <torrent-remote-control info-hash="event.episode.values.magnetHash" template-url="templates/torrentMiniRemoteProgress.html">{{ event.serie }} </torrent-remote-control>
 	  </div>
-	  <span ng-if="!event.episode.values.magnetHash" tooltip="{{event.episode.getFormattedEpisode()}}">
+	  <span ng-if="$root.getSetting('torrenting.enabled') != 1" tooltip="{{event.episode.getFormattedEpisode()}}">
 	  	{{ event.serie }}
 	  </span>
   </a>


### PR DESCRIPTION
Episodes that had the torrent controller would disappear if torrent functionality was disabled.

Simple fix, not sure if better way.
