### PR TITLE
Remove torrent control if torrents disabled

### DIFF
--- a/templates/episode.html
+++ b/templates/episode.html
@@ -60,7 +60,7 @@
   </div>
   <div class="col-md-4">
       <serie-details ng-if="serie" serie="serie">
-        <torrent-remote-control ng-if="episode && episode.magnetHash" info-hash="episode.magnetHash"></torrent-remote-control>
+        <torrent-remote-control ng-if="getSetting('torrenting.enabled') && episode && episode.magnetHash" info-hash="episode.magnetHash"></torrent-remote-control>
     </serie-details>
   </div>
 </div>


### PR DESCRIPTION
If torrent functionality is disabled, remove torrent mini controller from episode details view.
