### PR TITLE
Move Episode Ratings Chart to the Series View

### DIFF
--- a/templates/serieDetails.html
+++ b/templates/serieDetails.html
@@ -13,7 +13,7 @@
       </div>
     </div>
 	<div>
-    <h2 style='border-bottom:1px solid white; padding:5px; margin-top:12px !important'>Episode Ratings</h3>
+    <h2 style='border-bottom:1px solid white; padding:5px; margin-top:12px !important'>Episode Ratings</h2>
       <div class="chart">
         <div class="chartLine" ng-repeat="p in points track by $index" ng-style="{ height: p.y + '%', left: ((100 / points.length) * $index) + '%',  width: (100 / points.length)+'%', backgroundColor: 'rgba(255,255,255, 0.5)' }" ng-attr-tooltip="{{p.label}}"></div>
       </div>


### PR DESCRIPTION
Episode ratings chart don't seem to display while in Detailed Episode View and I don't think it's really needed there.

Series view:
![image](https://cloud.githubusercontent.com/assets/6258213/2968211/e7c74176-db3c-11e3-80b0-7649d6f9b66a.png)

Detailed Episodes View:
![image](https://cloud.githubusercontent.com/assets/6258213/2968213/ef4f0eba-db3c-11e3-938d-c1fab5b30d0f.png)
