### PR TITLE
Fixed dropdown menu going offscreen on last day

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -585,6 +585,10 @@ input[type=text], input[type=url], option, select {
 [date-picker] td:last-child {
     border-right: 0;
 }
+[date-picker] td:last-child ul.dropdown-menu {
+	left: auto;
+	right: 0px;
+}
 [date-picker] tr:last-child td {
     border-bottom: 0;
 }


### PR DESCRIPTION
Shows in the last column of the week had their drop-down menus going off the page

![image](https://cloud.githubusercontent.com/assets/6258213/3004221/81e87a86-dd86-11e3-9140-0b69110265ad.png)

I was looking into more advanced methods that detected if it would go outside the screen view and dynamically change it but I don't think it's needed for this column. For the row on the bottom however, depending on your screen size, something like this would be very useful as smaller screens on the bottom row all the shows seem to overflow the screen.
