### PR TITLE
Made BatchMarkEpisodes button easier to press

### DIFF
--- a/templates/serie.html
+++ b/templates/serie.html
@@ -35,8 +35,8 @@
             <div class="dropdown" tooltip="Click for options">
               <strong class="dropdown-toggle" style='white-space:nowrap'>Watched&nbsp;<i class="glyphicon glyphicon-chevron-down"></i>
               </strong>
-              <ul class="dropdown-menu" style='min-width: 300px'>
-                <li ng-click="markRangeWatchedStart()"><i class="glyphicon glyphicon-pencil"></i> Batch mark episodes as watched</li>
+              <ul class="dropdown-menu" style='min-width: 300px; padding: 5px; overflow-y: auto'>
+                <li ng-click="markRangeWatchedStart()" style='padding: 5px'><i class="glyphicon glyphicon-pencil"></i> Batch mark episodes as watched</li>
               </ul>
           </th>
         </tr>


### PR DESCRIPTION
The batch mark episodes button now takes up 50% of the box instead of the small amount it had before making it easier to press.

Also removed the scroll bar that wasn't needed
