### PR TITLE
Updated calender position depending on topsites

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -50,14 +50,12 @@ body {
     color: #444;
 }
 body > .container {
-    padding:20px;
-    padding-top:5px;
+    padding: 15px 20px 20px 20px;
 }
 .topsites-false {
-		padding-top:5px;
 }
 .topsites-true {
-		padding-top:30px;
+    padding-top: 25px;
 }
 h1, h2, h3 {
     font-family:'bebasregular', helvetica, sans-serif;
@@ -572,7 +570,6 @@ input[type=text], input[type=url], option, select {
 }
 [date-picker] {
     -webkit-user-select: none;
-    margin-top: 10px;
     transition: all 0.5s ease-in-out;
 }
 [date-picker]:hover {


### PR DESCRIPTION
Fixed the calenders position and paddings depending if topsites was enabled or not. #85 
- Changed the padding of .container to 15px from the top
- Updated .container CSS to use shorthand
- Removed CSS rules from topsites-false as no change is needed (handled by .container CSS rules)
- Updated topsites-true to move calender down a further 25px to accommodate for topsites
- Removed margin on [date-picker] as it wasn't needed

Previews:
![image](https://cloud.githubusercontent.com/assets/6258213/3009899/d2e01298-df0a-11e3-9541-dfe7fa83c4dd.png)
![image](https://cloud.githubusercontent.com/assets/6258213/3009900/db90381e-df0a-11e3-89e1-facc59557367.png)
