### PR TITLE
Rewrote the way list of series is displayed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -153,7 +153,7 @@ serieheader[mode='search'] h3 {
 serieheader[mode='poster'] {
     display:inline-block;
     height: 250px;
-    width: 185px;
+    margin:13px;
 }
 .series serieheader[mode='poster'] > div {
     background-color: transparent;
@@ -210,7 +210,7 @@ serieheader .poster {
     height: 240px;
     background-repeat:no-repeat;
     background-size: contain;
-    width:200px;
+    width:163px;
     background-position: center center;
 }
 .col-md-4 serieheader .poster {
@@ -310,14 +310,6 @@ series-list:hover h2, series-list.active h2 {
 }
 .series serieheader+serieheader > div {
     border-bottom:0;
-}
-.series serieheader:first-child > div {
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
-}
-.series serieheader:last-child > div {
-    border-bottom-left-radius: 10px;
-    border-bottom-right-radius: 10px;
 }
 .table.light {
     color: white;


### PR DESCRIPTION
Changed CSS rules around to allow for easier future changes related to Series List.

Not sure if the original way was that way for a reason but, it made it hard for me to test some things and it seemed unnecessarily hard to do what I was trying to do with the way that is was.
These changes don't really change anything visually but made it more 'modular' for future additions.

Because of the way the poster images are resized automatically by the CSS rule 'background-size: contain;' it makes the sizes of the div of the image (width) larger than the image and makes things a lot harder to add things to it and requires a lot of CSS to try and align items to fit those images.

These CSS changes make the image div the actual size of the resized image (because of 'background-size: contain;' ) which appears to be 163px which allows you to easily add things onto the image and not have to mess styling. Also made the parent div of the image with a margin of 13px which spaces the posters apart and makes it look normal. 

![image](https://cloud.githubusercontent.com/assets/6258213/3013072/86ab8b5e-df42-11e3-8e51-d470f5cac449.png)
