### PR TITLE
Update datePicker.js

### DIFF
--- a/js/vendor/datePicker.js
+++ b/js/vendor/datePicker.js
@@ -31,7 +31,8 @@ function getVisibleWeek(date, startSunday) {
         day = date.getDay();
     startSunday = startSunday ? 1 : 0;
 
-    if (date.getDay() === 0) {
+    if ( (date.getDay() === 0) && (startSunday === 1) ) {
+    } else if (date.getDay() === 0) {
         date.setDate(-5 -startSunday);
     } else {
         startSunday = startSunday ? 0 : 1;


### PR DESCRIPTION
Correct "month-mode"+"Sunday-first mode" calender display, when the 1st of the month falls on a Sunday. Fixes #119.
