### PR TITLE
Update backgroundRotator.js

### DIFF
--- a/js/directives/backgroundRotator.js
+++ b/js/directives/backgroundRotator.js
@@ -36,7 +36,7 @@ angular.module('DuckieTV.directives.backgroundrotator', [])
                 img.onerror = function(e) {
                     console.log("image load error!", e, url);
                 };
-                img.src = 'http://ir0.mobify.com/webp/' + url;
+                img.src = url;
             }
 
             $rootScope.$on($scope.channel, function(event, url) {


### PR DESCRIPTION
fix #126 by prefixing url with mobify only once. (it gets done by the template logic, doesn't need to be in load function as well).
