### PR TITLE
Save a few CPU cycles in calender.js

### DIFF
--- a/js/directives/calendar.js
+++ b/js/directives/calendar.js
@@ -66,8 +66,6 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
                 });
                 if (existing.length == 0) {
                     calendarEvents[date].push(events[i]);
-                } else {
-                    existing[0].episode = events[i].episode;
                 }
             }
             $rootScope.$broadcast('calendar:events', events);


### PR DESCRIPTION
save a few CPU cycles by removing what appears to be a redundant ELSE branch in the setEvents routine.
