### PR TITLE
update the calender.js event loader routine

### DIFF
--- a/js/directives/calendar.js
+++ b/js/directives/calendar.js
@@ -38,6 +38,7 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
                             start: new Date(data[i].get('firstaired')),
                             serie: cache[data[i].get('ID_Serie')].get('name'),
                             serieID: cache[data[i].get('ID_Serie')].get('TVDB_ID'),
+                            episodeID: data[i].get('TVDB_ID'),
                             episode: data[i]
                         });
                     }
@@ -62,7 +63,7 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
                     calendarEvents[date] = [];
                 }
                 var existing = calendarEvents[date].filter(function(el) {
-                    return el.serieID == events[i].serieID && el.start.toDateString() == events[i].start.toDateString()
+                    return el.episodeID == events[i].episodeID
                 });
                 if (existing.length == 0) {
                     calendarEvents[date].push(events[i]);


### PR DESCRIPTION
I'm not fixing any bugs with this, but it seems more reliable/logical to me to do this.

assuming that:
 a) an episode's TVDB_ID is unique, and 
 b) trakt.tv would never provide an episode without its TVDB_ID,
 then given the calender events are episode elements that should never have duplicates,
 it makes sense to use its TVDB_ID instead of (episode.serie_ID && episode.firstAired) during calender event loading.
If assumptions (a) and (b) are incorrect (or you prefer the current code) then do not accept this patch :-)
