### PR TITLE
Update calendar.js fix #121

### DIFF
--- a/js/directives/calendar.js
+++ b/js/directives/calendar.js
@@ -53,7 +53,7 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
         /** 
          * Merge any incoming new events with the events already in calendarEvents.
          * Adds them otherwise.
-         * THe calendarEvents cache is updated per day so the calendar doesn't refresh unnneccesarily
+         * The calendarEvents cache is updated per day so the calendar doesn't refresh unnecessarily
          */
         setEvents: function(events) {
             for (var i = 0; i < events.length; i++) {
@@ -62,6 +62,7 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
                 if (!(date in calendarEvents)) {
                     calendarEvents[date] = [];
                 }
+    			service.deleteDuplicate(events[i].episodeID,date);
                 var existing = calendarEvents[date].filter(function(el) {
                     return el.episodeID == events[i].episodeID
                 });
@@ -72,6 +73,19 @@ angular.module('DuckieTV.directives.calendar', ['DuckieTV.providers.favorites'])
                 }
             }
             $rootScope.$broadcast('calendar:events', events);
+        },
+        deleteDuplicate: function(duplicateID,eventDate) {
+            for (var aDate in calendarEvents) {
+                if (aDate !== eventDate) {
+                    var eventList = calendarEvents[aDate];
+					for (var index = 0; index < eventList.length; index++) {
+						if (eventList[index].episodeID === duplicateID) {
+							calendarEvents[aDate].splice(index,1); 
+							return;
+						}
+					}
+            	}
+            }
         },
         hasEvent: function(date) {
             return (new Date(date).toDateString() in calendarEvents);


### PR DESCRIPTION
Before adding/merging new day-events into the calender, scan the other days for duplicate episodes and remove them.
This resolves the issue where a schedule air-date change to an episode leaves the outdated entry in the calender, and avoids performing a full calendar refresh.
