### PR TITLE
correct week display for sundays

### DIFF
--- a/js/vendor/datePicker.js
+++ b/js/vendor/datePicker.js
@@ -31,7 +31,7 @@ function getVisibleWeek(date, startSunday) {
     var day = date.getDay(),
         startSunday = startSunday ? 0 : 1;
 
-    if (startSunday === 1 && date.getDate() == 1 && date.getDay() == 0) {
+    if (startSunday === 1 && date.getDay() == 0) {
         date.setDate(date.getDate() - 6);
     } else {
         date.setDate(date.getDate() - (date.getDay() - startSunday));


### PR DESCRIPTION
[blush] needed to correct WEEK display for all Sundays (not just on Sun 1st). It did not result on an event-date mismatch, but did cause the week display on Sundays to not display the current week but the one after.
Tested Sun-first and Mon-first WEEK display against the following dates: Sun 1,8,29 jun, Sun 2,30 Jul, Mon 2,30 Jun and Tue 1st Jul. Really think I've nailed it this time ;-)
