### PR TITLE
Fixed TVDB link on About Page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -19,7 +19,7 @@
 <p>If you find a bug, please report it on <a href="http://github.com/SchizoDuckie/DuckieTV/issues" target='_blank'>Github</a> So that I can keep track of it</p>
 
 <h3>TV Show information</h3>
-<p>DuckieTV makes extensive use of the base database built by <a href='http://thetvdb.org'>TheTVDB's open database</a>. If you find incorrect information about shows <a href='http://www.thetvdb.com/wiki/index.php/Main_Page'>please visit their Wiki Page and help them correct it</a></p>
+<p>DuckieTV makes extensive use of the base database built by <a href='http://thetvdb.com'>TheTVDB's open database</a>. If you find incorrect information about shows <a href='http://www.thetvdb.com/wiki/index.php/Main_Page'>please visit their Wiki Page and help them correct it</a></p>
 
 <h3>Privacy</h3>
 <strong>I DO NOT WANT YOUR DATA</strong>


### PR DESCRIPTION
Has this been wrong the whole time?
