### PR TITLE
Fixed poster height in rare cases

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -210,7 +210,7 @@ serieheader .banner {
 serieheader .poster {
     height: 240px;
     background-repeat:no-repeat;
-    background-size: contain;
+    background-size: 100% 100%;
     width: 163px;
     background-position: center center;
 }


### PR DESCRIPTION
Forced the background size of the poster to be the size of the div it is in (i think) which is the size of the poster anyway. All this does is stretch the image.

I swear I tried this before and it didn't work but it does now.

Also on a totally unrelated note, searching or typing for a series completely hangs my app and freezes. Could be an issue although, I am using Windows Vista :-1:  on an ancient PC that struggles with most trivial things.
