### PR TITLE
circular presentation graphs for #95

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -238,7 +238,7 @@ Listeners
 
       WatchlistCheckerService [ label="WatchlistCheckerService.js", shape=box,fillcolor="#efefef",color="white",style="filled"];
         watchlistcheck [label="watchlist:check", shape=box,fillcolor="white",style="filled"];
-}
+    }
 
 
 
@@ -386,4 +386,4 @@ Publishers
       WatchlistService [label="WatchlistService",shape=box,color="white",fillcolor="#efefef",style="filled"];
       watchlistupdated [label="watchlist:updated", shape=box,fillcolor="white",style="filled"];
     
-}
+    }


### PR DESCRIPTION
I've take the original Listeners and Publishers from the EVENTS.md and applied style=invis to retain the circular presentation.
Also changed the arrow direction for the Publishers.
But I have not made any corrections to the data nodes, I thought it best to leave that to you.
take a look below, and if you like then merge my EVENTS.md

![listeners](https://cloud.githubusercontent.com/assets/6933240/3533949/f5ccad10-07dd-11e4-8dfd-eec70ff67afe.png)

![publishers](https://cloud.githubusercontent.com/assets/6933240/3533917/409eff10-07dd-11e4-8ab8-cb555946568c.png)
