### PR TITLE
Fixed MarkAsWatched tooltip being cutoff

### DIFF
--- a/js/directives/episodeWatched.js
+++ b/js/directives/episodeWatched.js
@@ -11,7 +11,7 @@ angular.module('DuckieTV.directives.episodewatched', [])
         scope: {
             episode: '='
         },
-        template: ['<a ng-click="markWatched()" class="glyphicon" tooltip="{{getToolTip()}}" ng-class="{ \'glyphicon-eye-open\' : episode.get(\'watched\') ==  1, \'glyphicon-eye-close\' : episode.get(\'watched\') != 1 }" ng-transclude></a>'],
+        template: ['<a ng-click="markWatched()" style="width:100%" class="glyphicon" tooltip="{{getToolTip()}}" ng-class="{ \'glyphicon-eye-open\' : episode.get(\'watched\') ==  1, \'glyphicon-eye-close\' : episode.get(\'watched\') != 1 }" ng-transclude></a>'],
         link: function($scope) {
 
             $scope.tooltip = null;


### PR DESCRIPTION
Because of recent changes to the dropdown menu overflow css property the tooltip gets cutoff because of the way the Episode Watched button works, the tooltip is loaded in the episode-watched directive which creates a child `<a>` element which is only the width of the eye and that is where the tooltip loads, all this does is make that `<a>` take up 100% of width, didn't really bug test, not sure if there could be any errors with this but it does fix it or makes the tooltip in the center so it doesn't overflow.
