### PR TITLE
Fixed 'You have no series' alert

### DIFF
--- a/templates/home-series.html
+++ b/templates/home-series.html
@@ -49,7 +49,7 @@
           </serieHeader>
 
           <div ng-if="trendingSeries">
-            <p class="alert alert-info" ng-if="favorites.length == 0" style='margin:20px; position:relative; z-index:1000 ;text-align:left;'>
+            <p class="alert alert-info" ng-if="favorites.length == 0" style='margin:20px;text-align:left;white-space:normal'>
             <strong>{{'HOMESERIES/series-no/hdr'|translate}}</strong><br>
             {{'HOMESERIES/series-no/desc'|translate}}
             </p>


### PR DESCRIPTION
Changed the style for the 'You have no series' alert to fix white-space

Was looking like this for me; 
![image](https://cloud.githubusercontent.com/assets/6258213/3653650/db6d898e-1157-11e4-82ee-df2f3595526d.png)
