### PR TITLE
Add IMDB and Wikipedia link to series

### DIFF
--- a/_locales/en_us.json
+++ b/_locales/en_us.json
@@ -211,6 +211,7 @@
     "SERIEDETAILS/seasons/hdr": "Seasons",
     "SERIEDETAILS/status/hdr": "Status",
     "SERIEDETAILS/votes/lbl": "votes",
+    "SERIEDETAILS/links/hdr": "Links",
     "SERIEDETAILSjs/serie-delete-confirmed": "You confirmed 'No.'",
     "SERIEDETAILSjs/serie-delete-question/p1": "Do you really want to delete ",
     "SERIEDETAILSjs/serie-delete-question/p2": " from your favorites?",

--- a/templates/serieDetails.html
+++ b/templates/serieDetails.html
@@ -27,7 +27,7 @@
   <table class="table table-condensed light">
     <tbody>
       <tr>
-        <th>Links</th>
+        <th>{{'SERIEDETAILS/links/hdr'|translate}}</th>
         <td><a style="text-decoration: underline" ng-href="http://www.google.com/search?q={{serie.name}}+Wikipedia&btnI=745">Wikipedia</a> <a style="text-decoration: underline" ng-href="http://www.imdb.com/title/{{serie.IMDB_ID}}" ng-hide="serie.IMDB_ID < 1">IMDB</a></td>
       </tr>
       <tr>


### PR DESCRIPTION
Wikipedia link just Googles 'serie name + Wikipedia' and goes to first result, it's not always accurate but it is in most cases.
IMDB link takes you to the IMDB page using the provided IMDB_ID, and the button isn't shown when a serie
doesn't have an IMDB ID which does sometimes happen.

For now the links row is just at the top of the serie details, above the genre, airdate and such.
