### PR TITLE
Fix Episode & Serie Ctrl SceneNameCheck 

### DIFF
--- a/js/controllers/EpisodeCtrl.js
+++ b/js/controllers/EpisodeCtrl.js
@@ -2,7 +2,7 @@ angular.module('DuckieTV.controllers.episodes', [])
 
 .controller('EpisodeCtrl',
 
-    function(SettingsService, FavoritesService, SceneNameResolver, $routeParams, $scope, $rootScope, $filter) {
+    function(FavoritesService, SceneNameResolver, $routeParams, $scope, $rootScope, $filter) {
 
         $scope.searching = false;
         $scope.serie = null;

--- a/js/controllers/SerieCtrl.js
+++ b/js/controllers/SerieCtrl.js
@@ -2,7 +2,7 @@ angular.module('DuckieTV.controllers.serie', ['DuckieTV.directives.serieheader',
 
 .controller('SerieCtrl',
 
-    function(FavoritesService, SettingsService, SceneNameResolver, TraktTV, TorrentDialog, $routeParams, $scope, $rootScope, $injector, $filter, $q, $locale) {
+    function(FavoritesService, SceneNameResolver, TraktTV, TorrentDialog, $routeParams, $scope, $rootScope, $injector, $filter, $q, $locale) {
         $scope.episodes = [];
         $scope.episodeEntities = [];
         $scope.points = [];


### PR DESCRIPTION
Apart from some consistency of the functions they both add the torrent search quality the to serieName query which TorrentDialog.js searches and makes changing the quality in the TorrentDialog not work as those options/buttons don't change the actual name of the query being searched and torrentdialog already searches by default to your chosen quality

Question: Is SettingsService still required on these controllers now that the only thing that used it `SettingsService.get('torrenting.searchquality')` is gone?
