### PR TITLE
CSS fixes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -96,6 +96,7 @@ a:hover {
 }
 .tooltip .tooltip-arrow {
     border-top-color: white !important;
+    border-bottom-color: white !important;
 }
 .tooltip .tooltip-inner {
     background-color: white !important;
@@ -135,7 +136,6 @@ background-rotator, background-rotator > div {
     overflow: auto;
 }
 serieheader > div {
-    background-color: black;
     position: relative;
     overflow: hidden;
 }


### PR DESCRIPTION
**serieheader > div** : to my knowledge, this is an un-needed fallback style that causes issues with tooltips sometimes
**.tooltip .tooltip-arrow** : fixes the arrow being black (and unseen) when the tooltip appears below the element
