### PR TITLE
Better handling of trakt.tv errors in settings

### DIFF
--- a/js/controllers/TraktTVCtrl.js
+++ b/js/controllers/TraktTVCtrl.js
@@ -13,6 +13,8 @@
      $scope.traktTVSeries = [];
      $scope.tvdbSeries = {};
      $scope.traktTVSuggestions = false;
+     $scope.pushError = [false, null];
+     $scope.suggestionError = [false, null];
 
      $scope.encryptPassword = function() {
          if($scope.credentials.password !== null) {
@@ -21,7 +23,7 @@
             // Check account details (user / sha1 pass) with Trakt.TV
              TraktTV.checkDetails($scope.credentials.username, $scope.credentials.temphash).then(function(response) {
                  if(response == 'success') {
-                     // Update internal  values and save passwords in settings
+                     // Update internal values and save passwords in settings
                      $scope.credentials.passwordHash = $scope.credentials.temphash;
                      $scope.credentials.password = angular.copy($scope.credentials.passwordHash);
                      $rootScope.setSetting('trakttv.passwordHash', $scope.credentials.passwordHash);
@@ -40,7 +42,6 @@
         $scope.credentials.error = false;
         $rootScope.setSetting('trakttv.passwordHash', null);
         $rootScope.setSetting('trakttv.username', null);
-
      }
 
      $scope.isDownloaded = function(tvdb_id) {
@@ -69,6 +70,8 @@
              console.info("Found user suggestions from Trakt.tv", data);
              $scope.traktTVSuggestions = data;
              $scope.traktTVLoading = false;
+         }, function(err) {
+                $scope.suggestionError = [true, err];
          });
      };
 
@@ -102,6 +105,8 @@
                  }
              });
              $scope.traktTVSeries = data;
+         }, function(err) {
+                $scope.pushError = [true, err]
          });
 
          TraktTV.getUserShows($scope.credentials.username).then(function(data) {

--- a/templates/settings/trakttv.html
+++ b/templates/settings/trakttv.html
@@ -29,7 +29,7 @@
               <button ng-click="pushToTraktTV()" class="btn btn-success">{{'TRAKTTV/sync-push/btn'|translate}}</button><br>
               <div class="alert alert-danger" role="alert" ng-show="pushError[0]" style="white-space:initial">
                 <strong>{{pushError[1].status}} - {{pushError[1].statusText}}</strong>
-                    {{pushError[1].data.status}} - {{pushError[1].data.error}}
+                {{pushError[1].data.status}} - {{pushError[1].data.error}}
               </div><br>
             </p>
           </form>

--- a/templates/settings/trakttv.html
+++ b/templates/settings/trakttv.html
@@ -21,12 +21,16 @@
               <button ng-click='encryptPassword()' class="btn btn-info" ng-disabled="credentials.passwordHash !== null">{{'TRAKTTV/encrypt/btn'|translate}}</button> <button ng-click="clearCredentials()" class="btn btn-danger" >{{'TRAKTTV/clear-credentials/btn'|translate}}<br>
             </td>
             </tr></table>
-            <div class="alert alert-danger" role="alert" ng-show="credentials.error"><strong>{{'TRAKTTV/sync-error-event/alert'|translate}}</strong>{{'TRAKTTV/sync-error-reason/alert'|translate}}</div>
+            <div class="alert alert-danger" role="alert" ng-show="credentials.error">{{'TRAKTTV/sync-error-reason/alert'|translate}}</div>
             <button class="btn btn-success" style="margin-bottom:10px" ng-if="credentials.passwordHash && !getSetting('trakttv.sync')" ng-click="setSetting('trakttv.sync',true)">{{'TRAKTTV/sync-enabled/btn'|translate}}</button>
             <button class="btn btn-danger" style="margin-bottom:10px" ng-if="credentials.passwordHash && getSetting('trakttv.sync')" ng-click="setSetting('trakttv.sync',false)">{{'TRAKTTV/sync-disabled/btn'|translate}}</button>
             <p ng-if="credentials.passwordHash">
               <button ng-click="readTraktTV()" class="btn btn-success">{{'TRAKTTV/sync-import/btn'|translate}}</button>
-              <button ng-click="pushToTraktTV()" class="btn btn-success">{{'TRAKTTV/sync-push/btn'|translate}}</button><br><br>
+              <button ng-click="pushToTraktTV()" class="btn btn-success">{{'TRAKTTV/sync-push/btn'|translate}}</button><br>
+              <div class="alert alert-danger" role="alert" ng-show="pushError[0]" style="white-space:initial">
+                <strong>{{pushError[1].status}} - {{pushError[1].statusText}}</strong>
+                    {{pushError[1].data.status}} - {{pushError[1].data.error}}
+              </div><br>
             </p>
           </form>
 
@@ -42,9 +46,14 @@
               <div class="alert alert-info">{{'TRAKTTV/suggestions/alert'|translate}}</p></div>
               <button ng-click="getUserSuggestions()" class="btn btn-success">{{'TRAKTTV/suggestions-fetch/btn'|translate}}</button>
           </div>
-          <div ng-if="traktTVLoading" style='text-align:center; padding: 40px;'>
-            <p>{{'TRAKTTV/please-wait/lbl'|translate}}</p>
-            <img src='img/spinner.gif'>
+          <br>
+          <div class="alert alert-danger" role="alert" ng-show="suggestionError[0]" style="white-space:initial;text-align:left">
+              <strong>{{suggestionError[1].status}} - {{suggestionError[1].statusText}}</strong>
+              {{suggestionError[1].data.status}} - {{suggestionError[1].data.error}}
+          </div>
+          <div ng-if="traktTVLoading && !suggestionError[0]" style='text-align:center; padding: 20px;'>
+              <p>{{'TRAKTTV/please-wait/lbl'|translate}}</p>
+              <img src='img/spinner.gif'>
           </div>
           <div class="miniposter" ng-if="traktTVSuggestions">
             <h1>{{'TRAKTTV/suggestions-fetched/lbl'|translate}}</h1>


### PR DESCRIPTION
Adds more errors being displayed when a user tries to fetch series from trakt or suggestions telling them if an error has occured.

Also on Schizos command, these errors use the error data returned from the webserver and trakt (or something) which means they cannot be translated.

Errors are made up of 4 parts. What I am assuming is the web server errors being
`status: 503` & `statusText: Service Unavailable`
and then the additional data from trakt being
`.data.status: failure` & `.data.status: server is over capacity`

Note to self: People aren't machines.