### PR TITLE
Refactor trakt import code

### DIFF
--- a/_locales/de_de.json
+++ b/_locales/de_de.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Einstellungen",
     "COMMON/settings/lbl": "Einstellungen für ",
     "COMMON/show-files/btn": "Dateien anzeigen",
+    "COMMON/sort-column/tooltip": "Sortieren diese Spalte",
     "COMMON/specials/lbl": "Specials",
     "COMMON/split-button/sr": "Split-Taste",
     "COMMON/start/btn": "Starten",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Sie können alle Shows und beobachtete Episoden aus Ihrer Trakt.TV Konto mit dem Button in DuckieTV importieren",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Melden Sie sich",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Nur Import Sendungen von Ihrem Trakt.tv Sammlung",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Ihre PIN an Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Senden Sie zeigt zu Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Senden Sie alle Ihre DuckieTV Shows und beobachtete Episoden Ihr Konto bei trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "mit globalen Maximalgröße suchen",
     "TORRENTDIALOG/search-global-size-min/lbl": "mit globalen Mindestgröße suchen",
     "TORRENTDIALOG/search-include/lbl": "Suche mit weltweiten gehören Liste",
-    "COMMON/sort-column/tooltip": "Sortieren diese Spalte",
     "TORRENTFREAK/info/hdr": "info ",
     "TORRENTFREAK/rank/hdr": "Rang "
 }

--- a/_locales/en_uk.json
+++ b/_locales/en_uk.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Settings",
     "COMMON/settings/lbl": "Settings for ",
     "COMMON/show-files/btn": "Show files",
+    "COMMON/sort-column/tooltip": "Sort this column",
     "COMMON/specials/lbl": "Specials",
     "COMMON/split-button/sr": "Split button!",
     "COMMON/start/btn": "Start",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "You can import all shows and watched episodes from your Trakt.TV account into DuckieTV using the button below",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Login to ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Only import shows from your Trakt.tv Collection",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Your Trakt.TV PIN:",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Push shows to Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Push all your DuckieTV shows and watched episodes to your Trakt.TV account",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "search using global maximum size",
     "TORRENTDIALOG/search-global-size-min/lbl": "search using global minimum size",
     "TORRENTDIALOG/search-include/lbl": "search using global include list",
-    "COMMON/sort-column/tooltip": "Sort this column",
     "TORRENTFREAK/info/hdr": "Info",
     "TORRENTFREAK/rank/hdr": "Rank"
 }

--- a/_locales/en_us.json
+++ b/_locales/en_us.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Settings",
     "COMMON/settings/lbl": "Settings for ",
     "COMMON/show-files/btn": "Show files",
+    "COMMON/sort-column/tooltip": "Sort this column",
     "COMMON/specials/lbl": "Specials",
     "COMMON/split-button/sr": "Split button!",
     "COMMON/start/btn": "Start",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "You can import all shows and watched episodes from your Trakt.TV account into DuckieTV using the button below",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Login to ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Only import shows from your Trakt.tv Collection",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Your Trakt.TV PIN:",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Push shows to Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Push all your shows and watched episodes on DuckieTV to your Trakt.TV account",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "search using global maximum size",
     "TORRENTDIALOG/search-global-size-min/lbl": "search using global minimum size",
     "TORRENTDIALOG/search-include/lbl": "search using global include list",
-    "COMMON/sort-column/tooltip": "Sort this column",
     "TORRENTFREAK/info/hdr": "Info",
     "TORRENTFREAK/rank/hdr": "Rank"
 }

--- a/_locales/es_es.json
+++ b/_locales/es_es.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Configuración",
     "COMMON/settings/lbl": "Ajustes para ",
     "COMMON/show-files/btn": "Mostrar archivos",
+    "COMMON/sort-column/tooltip": "Ordenar esta columna",
     "COMMON/specials/lbl": "Especiales",
     "COMMON/split-button/sr": "Botón de división",
     "COMMON/start/btn": "Comenzar",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Puede importar todos los programas y episodios vistos desde su cuenta Trakt.TV en DuckieTV usando el botón de abajo",
     "SETTINGS/TRAKT-IMPORT/hdr": "Importar Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Inicia sesión a ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Solamente los programas de importación de su colección Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Su PIN en Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Enviar programas de TV a Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Enviar todos sus programas DuckieTV y episodios vistos a su cuenta en trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "buscar utilizando el tamaño máximo global",
     "TORRENTDIALOG/search-global-size-min/lbl": "buscar utilizando el tamaño mínimo global",
     "TORRENTDIALOG/search-include/lbl": "buscar usando mundial incluyen la lista",
-    "COMMON/sort-column/tooltip": "Ordenar esta columna",
     "TORRENTFREAK/info/hdr": "Info",
     "TORRENTFREAK/rank/hdr": "Clasificación"
 }

--- a/_locales/fr_fr.json
+++ b/_locales/fr_fr.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Paramètres",
     "COMMON/settings/lbl": "Paramètres pour ",
     "COMMON/show-files/btn": "Afficher les fichiers",
+    "COMMON/sort-column/tooltip": "Trier cette colonne",
     "COMMON/specials/lbl": "Promos",
     "COMMON/split-button/sr": "bouton scission",
     "COMMON/start/btn": "Démarrer ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/click-add-show/lbl": "Cliquez pour ajouter une série",
     "SETTINGS/TRAKT-IMPORT/hdr": "Importer depuis Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Se connecter à ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Seuls les spectacles à l'importation à partir de votre collection Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Mot de passe:",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Envoyer spectacles à Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Envoyez tous vos spectacles de DuckieTV et épisodes regardés à votre compte à trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "la recherche en utilisant la taille maximale globale",
     "TORRENTDIALOG/search-global-size-min/lbl": "la recherche en utilisant la taille minimum global",
     "TORRENTDIALOG/search-include/lbl": "recherche en utilisant la liste incluent globale",
-    "COMMON/sort-column/tooltip": "Trier cette colonne",
     "TORRENTFREAK/info/hdr": "Infos ",
     "TORRENTFREAK/rank/hdr": "Rang "
 }

--- a/_locales/it_it.json
+++ b/_locales/it_it.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Impostazioni",
     "COMMON/settings/lbl": "Impostazioni per ",
     "COMMON/show-files/btn": "Mostra i file",
+    "COMMON/sort-column/tooltip": "Ordinare questa colonna",
     "COMMON/specials/lbl": "Speciali",
     "COMMON/split-button/sr": "Bottono Split!",
     "COMMON/start/btn": "Inizio",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "È possibile importare dal tuo account Trakt.TV in DuckieTV tutte le serie e gli episodi guardati utilizzando il pulsante qui sotto",
     "SETTINGS/TRAKT-IMPORT/hdr": "Importa da Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Login per",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Solo spettacoli di importazione dalla Collezione Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Il PIN a Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Invia spettacoli da Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Invia da DuckieTV al tuo account Trakt.TV tutte le serie e gli episodi guardati",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "la ricerca utilizzando dimensione massima globale",
     "TORRENTDIALOG/search-global-size-min/lbl": "la ricerca utilizzando dimensione minima globale",
     "TORRENTDIALOG/search-include/lbl": "Cerca usando globale inclusione lista",
-    "COMMON/sort-column/tooltip": "Ordinare questa colonna",
     "TORRENTFREAK/info/hdr": "Informazioni",
     "TORRENTFREAK/rank/hdr": "Rank"
 }

--- a/_locales/ja_jp.json
+++ b/_locales/ja_jp.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "[設定]",
     "COMMON/settings/lbl": "設定 ",
     "COMMON/show-files/btn": "ファイルを表示",
+    "COMMON/sort-column/tooltip": "この列をソート",
     "COMMON/specials/lbl": "スペシャル",
     "COMMON/split-button/sr": "分割ボタン",
     "COMMON/start/btn": "スタート ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "あなたは下のボタンを使用してDuckieTVにあなたのTrakt.TVアカウントから全番組と見エピソードをインポートすることができます",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TVインポート",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "にログイン",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "あなたのTrakt.tvコレクションからのみ輸入ショー",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Trakt.TVで暗証番号",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Trakt.TVに番組を送信",
     "SETTINGS/TRAKT-IMPORT/push/desc": "trakt.TVでアカウントにすべてのあなたの<br>DuckieTV番組や視聴エピソードを送ります",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "グローバルな最大サイズを使用して検索",
     "TORRENTDIALOG/search-global-size-min/lbl": "グローバルな最小サイズを使用して検索",
     "TORRENTDIALOG/search-include/lbl": "グローバルリストが含まれて検索",
-    "COMMON/sort-column/tooltip": "この列をソート",
     "TORRENTFREAK/info/hdr": "インフォメーション ",
     "TORRENTFREAK/rank/hdr": "ランク "
 }

--- a/_locales/ko_kr.json
+++ b/_locales/ko_kr.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "설정",
     "COMMON/settings/lbl": "에 대한 설정 ",
     "COMMON/show-files/btn": "보기 파일",
+    "COMMON/sort-column/tooltip": "이 열을 정렬",
     "COMMON/specials/lbl": "특가",
     "COMMON/split-button/sr": "분할 버튼",
     "COMMON/start/btn": "스타트 ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "당신은 아래의 버튼을 사용하여 DuckieTV로 Trakt.TV 계정에서 모든 프로그램 및 시청 에피소드를 가져올 수 있습니다",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV 가져 오기",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "로그인",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "당신의 Trakt.tv 컬렉션에서 만 수입 쇼",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Trakt.TV에서 PIN 번호",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Trakt.TV을 보여줍니다 보내기",
     "SETTINGS/TRAKT-IMPORT/push/desc": "trakt.TV에서 계정에 모든 DuckieTV 프로그램 및 시청 에피소드 보내기",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "세계 최대 크기를 사용하여 검색",
     "TORRENTDIALOG/search-global-size-min/lbl": "세계 최소 크기를 사용하여 검색",
     "TORRENTDIALOG/search-include/lbl": "전역 목록을 포함하여 검색",
-    "COMMON/sort-column/tooltip": "이 열을 정렬",
     "TORRENTFREAK/info/hdr": "정보 ",
     "TORRENTFREAK/rank/hdr": "계급 "
 }

--- a/_locales/nb_no.json
+++ b/_locales/nb_no.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Innstillinger",
     "COMMON/settings/lbl": "Innstillinger for ",
     "COMMON/show-files/btn": "Vis filer",
+    "COMMON/sort-column/tooltip": "Sortere denne kolonnen",
     "COMMON/specials/lbl": "Spesialer",
     "COMMON/split-button/sr": "Splitt-knapp!",
     "COMMON/start/btn": "Start",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Du kan importere alle serier and episoder merket sett fra din Trakt.TV konto til DuckieTV ved å bruke knappen nedenfor",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Importering",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Logg inn til ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Bare importere programmer fra din Trakt.tv Collection",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Din Trakt.TV PIN:",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Dytt serier til Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Dytter alle dine serier og sett episoder på DuckieTV til din Trakt.TV konto",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "søke ved hjelp global maksimal størrelse",
     "TORRENTDIALOG/search-global-size-min/lbl": "søke ved hjelp global minimumsstørrelse",
     "TORRENTDIALOG/search-include/lbl": "søke ved hjelp global inkluderer liste",
-    "COMMON/sort-column/tooltip": "Sortere denne kolonnen",
     "TORRENTFREAK/info/hdr": "Info",
     "TORRENTFREAK/rank/hdr": "Rangering"
 }

--- a/_locales/nl_nl.json
+++ b/_locales/nl_nl.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Instellingen",
     "COMMON/settings/lbl": "Instellingen voor ",
     "COMMON/show-files/btn": "Toon bestanden",
+    "COMMON/sort-column/tooltip": "Sorteren deze kolom",
     "COMMON/specials/lbl": "Specials",
     "COMMON/split-button/sr": "split-knop",
     "COMMON/start/btn": "Starten",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "U kunt bekeken series en afleveringen van uw Trakt.TV account naar DuckieTV importeren via de knop hieronder",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "log in om een",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Alleen import shows van uw Trakt.tv Collection",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Uw pincode bij Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Stuur series naar Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Stuur al uw DuckieTV series en bekeken afleveringen naar uw account op Trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "zoeken met behulp van wereldwijde maximale grootte",
     "TORRENTDIALOG/search-global-size-min/lbl": "zoeken met behulp van wereldwijde minimummaat",
     "TORRENTDIALOG/search-include/lbl": "zoeken met behulp van wereldwijde bevatten lijst",
-    "COMMON/sort-column/tooltip": "Sorteren deze kolom",
     "TORRENTFREAK/info/hdr": "Informatie",
     "TORRENTFREAK/rank/hdr": "Score"
 }

--- a/_locales/pt_pt.json
+++ b/_locales/pt_pt.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Configurações",
     "COMMON/settings/lbl": "Configurações para ",
     "COMMON/show-files/btn": "Mostrar arquivos",
+    "COMMON/sort-column/tooltip": "Classificar esta coluna",
     "COMMON/specials/lbl": "Especiais",
     "COMMON/split-button/sr": "botão de divisão",
     "COMMON/start/btn": "começo ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Você pode importar todos os shows e episódios assistiu de sua conta Trakt.TV em DuckieTV utilizando o botão abaixo",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Entre para",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Só mostra importação de sua coleção Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "O seu PIN em Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Enviar shows para Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Envie todos os seus programas DuckieTV e episódios assistidos sua conta em trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "pesquisar usando tamanho máximo global",
     "TORRENTDIALOG/search-global-size-min/lbl": "pesquisar usando tamanho mínimo global",
     "TORRENTDIALOG/search-include/lbl": "pesquisar usando global incluem lista",
-    "COMMON/sort-column/tooltip": "Classificar esta coluna",
     "TORRENTFREAK/info/hdr": "Informações ",
     "TORRENTFREAK/rank/hdr": "categoria "
 }

--- a/_locales/ro_ro.json
+++ b/_locales/ro_ro.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Setări",
     "COMMON/settings/lbl": "Setările pentru ",
     "COMMON/show-files/btn": "Arată fișierele",
+    "COMMON/sort-column/tooltip": "Sorta coloana",
     "COMMON/specials/lbl": "Episoade speciale",
     "COMMON/split-button/sr": "butonul divizat",
     "COMMON/start/btn": " Începeți",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Puteți importa toate serialele și episoadele vizionate din contul de Trakt.TV în DuckieTV folosind butonul de mai jos",
     "SETTINGS/TRAKT-IMPORT/hdr": "Import Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Logare în ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Doar spectacole din colecția dvs. de Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "PIN-ul de la Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Trimite spectacole de Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Trimite toate emisiunile DuckieTV și episoade urmarit la contul dvs. la trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "căutare folosind dimensiune maximă globală",
     "TORRENTDIALOG/search-global-size-min/lbl": "căutare folosind dimensiune minimă globală",
     "TORRENTDIALOG/search-include/lbl": "căutare folosind lista Global includ",
-    "COMMON/sort-column/tooltip": "Sorta coloana",
     "TORRENTFREAK/info/hdr": "Info",
     "TORRENTFREAK/rank/hdr": "Rang"
 }

--- a/_locales/ru_ru.json
+++ b/_locales/ru_ru.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Настройки",
     "COMMON/settings/lbl": "Настройки для ",
     "COMMON/show-files/btn": "Показать файлы",
+    "COMMON/sort-column/tooltip": "Сортировка этот столбец",
     "COMMON/specials/lbl": "Спецвыпуски",
     "COMMON/split-button/sr": "Split button!",
     "COMMON/start/btn": "Старт",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Вы можете сделать импорт всех шоу и просмотренных эпизодов из аккаунта Trakt.TV в DuckieTV",
     "SETTINGS/TRAKT-IMPORT/hdr": "Импорт Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Войти в ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Только импорт-шоу из вашей коллекции Trakt.tv",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Ваш Trakt.TV PIN:",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Отправить шоу в Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Отправить все шоу и просмотренные эпизоды из DuckieTV в аккаунт Trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "поиск с использованием глобальной максимального размера",
     "TORRENTDIALOG/search-global-size-min/lbl": "поиск с использованием глобального минимального размера",
     "TORRENTDIALOG/search-include/lbl": "поиск в списке по умолчанию",
-    "COMMON/sort-column/tooltip": "Сортировка этот столбец",
     "TORRENTFREAK/info/hdr": "Информация",
     "TORRENTFREAK/rank/hdr": "Оценка"
 }

--- a/_locales/sl_si.json
+++ b/_locales/sl_si.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Nastavitve",
     "COMMON/settings/lbl": "Nastavitve za ",
     "COMMON/show-files/btn": "Prikaži datoteke",
+    "COMMON/sort-column/tooltip": "Ta stolpec razvrstite",
     "COMMON/specials/lbl": "Posebna ponudba",
     "COMMON/split-button/sr": "gumb za split",
     "COMMON/start/btn": "Začetek",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Lahko uvozite vse oddaje in gledane epizode iz vašega Trakt.TV računa v DuckieTV z gumbom spodaj",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Uvozi",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "Prijava na ",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Le uvoza kaže iz vašega Trakt.tv zbirke",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Vaš PIN na Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Pošlji kaže, da Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Pošlji vse svoje DuckieTV oddaj in gledal epizode na vaš račun na trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "iskanje s pomočjo globalnega največjo velikost",
     "TORRENTDIALOG/search-global-size-min/lbl": "iskanje s pomočjo globalnega najmanjšo velikost",
     "TORRENTDIALOG/search-include/lbl": "iskanje s pomočjo globalnega vključuje seznam",
-    "COMMON/sort-column/tooltip": "Ta stolpec razvrstite",
     "TORRENTFREAK/info/hdr": "Informacije",
     "TORRENTFREAK/rank/hdr": "Rank"
 }

--- a/_locales/sv_se.json
+++ b/_locales/sv_se.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "Inställningar",
     "COMMON/settings/lbl": "Inställningar för ",
     "COMMON/show-files/btn": "Visa filer",
+    "COMMON/sort-column/tooltip": "Sortera denna kolumn",
     "COMMON/specials/lbl": "Specialerbjudanden",
     "COMMON/split-button/sr": "split knapp",
     "COMMON/start/btn": "Början ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "Du kan importera alla shower och bevakade episoder från ditt Trakt.TV konto till DuckieTV med knappen nedan",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV Import",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "logga in till",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "Endast import visar från din Trakt.tv Collection",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "Din PIN-kod på Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "Skicka shower till Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "Skicka alla dina DuckieTV visar och såg episoder på ditt konto på trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "söka med global maximal storlek",
     "TORRENTDIALOG/search-global-size-min/lbl": "söka med globala minimistorlek",
     "TORRENTDIALOG/search-include/lbl": "söka med global inkluderar listan",
-    "COMMON/sort-column/tooltip": "Sortera denna kolumn",
     "TORRENTFREAK/info/hdr": "info ",
     "TORRENTFREAK/rank/hdr": "Placering "
 }

--- a/_locales/zh_cn.json
+++ b/_locales/zh_cn.json
@@ -155,6 +155,7 @@
     "COMMON/settings/hdr": "设置",
     "COMMON/settings/lbl": "对于设置 ",
     "COMMON/show-files/btn": "显示文件",
+    "COMMON/sort-column/tooltip": "排序此列",
     "COMMON/specials/lbl": "特价",
     "COMMON/split-button/sr": "劈扣",
     "COMMON/start/btn": "开始 ",
@@ -423,6 +424,7 @@
     "SETTINGS/TRAKT-IMPORT/desc": "您可以使用下面的按钮,输入您的帐号Trakt.TV所有的节目和观看剧集进入DuckieTV",
     "SETTINGS/TRAKT-IMPORT/hdr": "Trakt.TV进口",
     "SETTINGS/TRAKT-IMPORT/login-to/btn": "登录",
+    "SETTINGS/TRAKT-IMPORT/only-collection/lbl": "只有进口节目从Trakt.tv收藏",
     "SETTINGS/TRAKT-IMPORT/password/hdr": "你的PIN在Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/btn": "发送给节目Trakt.TV",
     "SETTINGS/TRAKT-IMPORT/push/desc": "发送您的所有DuckieTV节目和观看的情节到您的帐户trakt.TV",
@@ -534,7 +536,6 @@
     "TORRENTDIALOG/search-global-size-max/lbl": "搜索使用的全球最大尺寸",
     "TORRENTDIALOG/search-global-size-min/lbl": "搜索使用全球最小尺寸",
     "TORRENTDIALOG/search-include/lbl": "使用搜索全球包括列表",
-    "COMMON/sort-column/tooltip": "排序此列",
     "TORRENTFREAK/info/hdr": "信息 ",
     "TORRENTFREAK/rank/hdr": "秩 "
 }

--- a/templates/settings/trakt-import.html
+++ b/templates/settings/trakt-import.html
@@ -66,6 +66,11 @@
     <h2 translate-once="SETTINGS/TRAKT-IMPORT/hdr"></h2>
     <p translate-once="SETTINGS/TRAKT-IMPORT/desc"></p>
 
+    <div class="checkbox">
+      <input type="checkbox" ng-model="trakt.onlyCollection" id="onlyCollection">
+      <label for="onlyCollection" translate-once="Only import shows from your Trakt.tv Collection"></label>
+    </div>
+
     <a ng-click="trakt.readTraktTV()" class="btn btn-info">
       <i class="glyphicon glyphicon-import" style="float:left;top:3px"></i> <span translate-once="SETTINGS/TRAKT-IMPORT/sync-import/btn"></span>
     </a>
@@ -83,9 +88,9 @@
   </div>
   <div class="miniposter x2" ng-if="trakt.traktTVSeries[0]" style="text-align:center">
     <serieheader style='display:inline-block; margin:5px;' data="serie" no-badge="1" no-button="1" no-overview="1" no-title="1" mode="poster" ng-repeat="serie in trakt.traktTVSeries">
-      <em class="earmark" ng-show="trakt.isAdded(serie.tvdb_id)"><i class='glyphicon glyphicon-ok'></i></em>
+      <em class="earmark" ng-hide="trakt.isAdding(serie.tvdb_id)"><i class='glyphicon glyphicon-ok'></i></em>
       <em class="earmark adding" ng-show="trakt.isAdding(serie.tvdb_id)"><loading-spinner></loading-spinner></em>
     </serieheader>
-    <small style="display:block"<span translate-once="SETTINGS/TRAKT-IMPORT/watched-episodes/lbl"></span> {{ trakt.countWatchedEpisodes(serie) }} </small>
+    <small style="display:block"><span translate-once="SETTINGS/TRAKT-IMPORT/watched-episodes/lbl"></span> {{ trakt.watchedEpisodes }} </small>
   </div>
 </div>

--- a/templates/settings/trakt-import.html
+++ b/templates/settings/trakt-import.html
@@ -68,7 +68,7 @@
 
     <div class="checkbox">
       <input type="checkbox" ng-model="trakt.onlyCollection" id="onlyCollection">
-      <label for="onlyCollection" translate-once="Only import shows from your Trakt.tv Collection"></label>
+      <label for="onlyCollection" translate-once="SETTINGS/TRAKT-IMPORT/only-collection/lbl"></label>
     </div>
 
     <a ng-click="trakt.readTraktTV()" class="btn btn-info">
@@ -88,8 +88,8 @@
   </div>
   <div class="miniposter x2" ng-if="trakt.traktTVSeries[0]" style="text-align:center">
     <serieheader style='display:inline-block; margin:5px;' data="serie" no-badge="1" no-button="1" no-overview="1" no-title="1" mode="poster" ng-repeat="serie in trakt.traktTVSeries">
-      <em class="earmark" ng-hide="trakt.isAdding(serie.tvdb_id)"><i class='glyphicon glyphicon-ok'></i></em>
-      <em class="earmark adding" ng-show="trakt.isAdding(serie.tvdb_id)"><loading-spinner></loading-spinner></em>
+      <em class="earmark" ng-hide="trakt.isAdding(serie.trakt_id)"><i class='glyphicon glyphicon-ok'></i></em>
+      <em class="earmark adding" ng-show="trakt.isAdding(serie.trakt_id)"><loading-spinner></loading-spinner></em>
     </serieheader>
     <small style="display:block"><span translate-once="SETTINGS/TRAKT-IMPORT/watched-episodes/lbl"></span> {{ trakt.watchedEpisodes }} </small>
   </div>


### PR DESCRIPTION
Completely recoded the trakt import code and added an extra option.

Only took me all day but, completely redid the import logic to be more robust are follow a proper chain of functions. It should be more efficient as now we will not re-add shows that are already in our library. While the code for this was there it didn't seem to always work. I am unsure why. This also closes #336 and, while not exactly my fix, the chance of #640 happening should also be lower.

I also added a new feature/option, `Only import shows from your Trakt.tv Collection`. This differs slightly in the original method of importing. By default we will import every show you have ever watched and every show in your collection. While this is probably fine for a lot of people. I have a lot of shows on trakt.tv that I don't have in my collection and don't really want on DuckieTV, the new option will only add a show (and any watched episodes it has) if it is in your Collection.
For this option to properly work however we do need to add another feature sometime down the line to automatically sync series you add and remove from your library to your Trakt.TV collection.

I've painfully done a lot of testing and it has worked fine for me but, more testing would be ideal as I cannot test all possible edge cases and I might have missed something obvious.

Also, all the checks in the import use the series TVDB_ID as it originally was but with the recent shift to TRAKT_ID, should we also switch all these?