### PR TITLE
eztv: change to *.wf mirror

### DIFF
--- a/js/services/SettingsService.js
+++ b/js/services/SettingsService.js
@@ -145,7 +145,7 @@ DuckieTV.factory('SettingsService', ['$injector', 'availableLanguageKeys', 'cust
         'mirror.1337x': 'https://1337x.to',
         'mirror.ETag': 'https://extratorrent.st',
         'mirror.EXT': 'https://ext.to',
-        'mirror.EzTVag': 'https://eztv.re',
+        'mirror.EzTVag': 'https://eztv.wf',
         'mirror.Idope': 'https://idope.se',
         'mirror.IsoHunt2': 'https://isohunt.tv',
         'mirror.KATws': 'https://kickass.ws',


### PR DESCRIPTION
The *.wf mirror is the only one that works for me without a proxy/VPN, due to government-mandated ISP blocks and DPI (so just changing your DNS doesn't work).

If this domain causes issues for others though, this can be closed.