### PR TITLE
Show air time with the date on the episode details

### DIFF
--- a/templates/sidepanel/episode-details.html
+++ b/templates/sidepanel/episode-details.html
@@ -13,7 +13,7 @@
   </h2>
 
   <h3>{{::sidepanel.episode.episodename}}</h3>
-  <h5 style="text-align: center;">{{::sidepanel.episode.firstaired | date: 'shortDate'}}</h5>
+  <h5 style="text-align: center;">{{::sidepanel.episode.firstaired | date: 'medium'}}</h5>
   <p class="overview" style="text-align:justify">{{::sidepanel.episode.overview}}</p>
 
   <table class="buttons" width="100%" border="0">


### PR DESCRIPTION
Show air time with the date on the episode details. Previously it was harder to find and users had to mainly rely on the hover to find it.