### PR TITLE
Preserve watched timestamp from Trakt.TV during import

### DIFF
--- a/js/CRUD.entities.js
+++ b/js/CRUD.entities.js
@@ -310,10 +310,11 @@ CRUD.define(Serie, {
   markSerieAsWatched: function(watchedDownloadedPaired, $rootScope) {
     var self = this
     return new Promise(function(resolve) {
+      var now = new Date()
       self.getEpisodes().then(function(episodes) {
         episodes.forEach(function(episode) {
           if (episode.hasAired() && (!episode.isWatched())) {
-            return episode.markWatched(watchedDownloadedPaired, $rootScope)
+            return episode.markWatched(watchedDownloadedPaired, now, $rootScope)
           }
         })
         return resolve(true)
@@ -415,11 +416,12 @@ CRUD.define(Season, {
   },
   markSeasonAsWatched: function(watchedDownloadedPaired, $rootScope) {
     var self = this
+    var now = new Date()
     return new Promise(function(resolve) {
       self.getEpisodes().then(function(episodes) {
         episodes.forEach(function(episode) {
           if (episode.hasAired() && (!episode.isWatched())) {
-            return episode.markWatched(watchedDownloadedPaired, $rootScope)
+            return episode.markWatched(watchedDownloadedPaired, now, $rootScope)
           }
         })
         self.watched = 1
@@ -559,12 +561,12 @@ CRUD.define(Episode, {
     return this.leaked && parseInt(this.leaked) == 1
   },
 
-  markWatched: function(watchedDownloadedPaired, $rootScope) {
+  markWatched: function(watchedDownloadedPaired, watchedAt, $rootScope) {
     if (typeof watchedDownloadedPaired === 'undefined') {
       watchedDownloadedPaired = true
     }
     this.watched = 1
-    this.watchedAt = new Date().getTime()
+    this.watchedAt = (watchedAt || new Date()).getTime()
     if (watchedDownloadedPaired) {
       // if you are marking this as watched you must have also downloaded it!
       this.downloaded = 1

--- a/js/controllers/settings/TraktTVCtrl.js
+++ b/js/controllers/settings/TraktTVCtrl.js
@@ -181,7 +181,9 @@ DuckieTV.controller('TraktTVCtrl', ['$rootScope', 'TraktTVv2', 'FavoritesService
                         console.warn('Episode s%se%s not found for %s', season.number, episode.number, show.name)
                       } else {
                         vm.watchedEpisodes++
-                        return epi.markWatched(vm.downloadedPaired)
+                        var d = new Date(episode.last_watched_at)
+                        if (isNaN(d)) d = new Date()
+                        return epi.markWatched(vm.downloadedPaired, d)
                       }
                     }).catch(function() {})
                   }))

--- a/js/directives/episodeWatched.js
+++ b/js/directives/episodeWatched.js
@@ -28,7 +28,7 @@ DuckieTV.directive('episodeWatched', ['$filter', '$injector',
           if (episode.isWatched()) {
             episode.markNotWatched($injector.get('$rootScope'))
           } else {
-            episode.markWatched($injector.get('SettingsService').get('episode.watched-downloaded.pairing'), $injector.get('$rootScope'))
+            episode.markWatched($injector.get('SettingsService').get('episode.watched-downloaded.pairing'), new Date(), $injector.get('$rootScope'))
           }
         }
       }

--- a/js/services/CalendarEvents.js
+++ b/js/services/CalendarEvents.js
@@ -213,10 +213,11 @@ DuckieTV.factory('CalendarEvents', ['$rootScope', 'FavoritesService', 'SettingsS
 
       markDayWatched: function(day, rootScope, downloadedPaired) {
         var str = day instanceof Date ? day.toDateString() : new Date(day).toDateString()
+        var now = new Date()
         if (str in calendarEvents) {
           calendarEvents[str].map(function(calEvent) {
             if (calEvent.episode.hasAired()) {
-              calEvent.episode.markWatched(downloadedPaired, rootScope)
+              calEvent.episode.markWatched(downloadedPaired, now, rootScope)
             }
           })
         }

--- a/templates/event.html
+++ b/templates/event.html
@@ -19,7 +19,7 @@
     </div>
     <!-- episode watched, show icon. -->
     <span ng-show="episode.isWatched()" class="glyphicon glyphicon-ok watchedpos"></span>
-    <span ng-show="!episode.isWatched() && (episode.hasAired() || episode.isLeaked())" class="glyphicon glyphicon-unchecked markpos" uib-tooltip="{{ 'COMMON/not-marked/lbl'|translate }}" tooltip-append-to-body="true" tooltip-placement="left" ng-click="episode.markWatched(getSetting('episode.watched-downloaded.pairing'), $root); $event.stopPropagation();"></span>
+    <span ng-show="!episode.isWatched() && (episode.hasAired() || episode.isLeaked())" class="glyphicon glyphicon-unchecked markpos" uib-tooltip="{{ 'COMMON/not-marked/lbl'|translate }}" tooltip-append-to-body="true" tooltip-placement="left" ng-click="episode.markWatched(getSetting('episode.watched-downloaded.pairing'), null, $root); $event.stopPropagation();"></span>
     <span ng-show="count > 2" class="badge" ng-click="expand()">x{{count}}</span>
   </a>
 </div>


### PR DESCRIPTION
Currently `epi.markWatched` always uses the current date, so as a result, when Trakt.TV syncs, all of the watched-at date will be wrong (i.e. the time of import). This patch makes `markWatched` accept a date to set, and uses the `last_watched_at` field from Trakt.TV during import to fill this in, thereby preserving the watched-at date.

Some background: I was using Trakt to add shows watched at the "release date" and I hoped to pull that info back into DuckieTV to "correct" some of the dates, but I noticed that now all the dates were wrong.