### PR TITLE
Update TheRARBG URL

### DIFF
--- a/js/services/SettingsService.js
+++ b/js/services/SettingsService.js
@@ -151,7 +151,7 @@ DuckieTV.factory('SettingsService', ['$injector', 'availableLanguageKeys', 'cust
         'mirror.LimeTorrents': 'https://www.limetorrents.lol',
         'mirror.Nyaa': 'https://nyaa.si',
         'mirror.ShowRSS': 'https://showrss.info',
-        'mirror.theRARBG': 'https://t-rb.org/',
+        'mirror.theRARBG': 'https://therarbg.to/',
         'mirror.ThePirateBay': 'https://thepiratebay0.org/',
         'mirror.TorrentDownloads': 'https://www.torrentdownloads.pro',
         'mirror.TGx': 'https://torrentgalaxy.to',


### PR DESCRIPTION
All mirrors are down, currently only the primary *.to and *.com domains are active.