### PR TITLE
[codex] Recover stale calendar data on startup

### DIFF
--- a/js/services/TraktTVUpdateService.js
+++ b/js/services/TraktTVUpdateService.js
@@ -6,6 +6,7 @@
  */
 DuckieTV.factory('TraktTVUpdateService', ['$q', 'TraktTVv2', 'FavoritesService', 'FanartService', '$rootScope',
   function($q, TraktTVv2, FavoritesService, FanartService, $rootScope) {
+    var RECOVERY_LOOKBACK_MS = 1000 * 60 * 60 * 24 * 7
     var service = {
       /**
        * Update shows in favorites list
@@ -78,6 +79,49 @@ DuckieTV.factory('TraktTVUpdateService', ['$q', 'TraktTVv2', 'FavoritesService',
 
         localStorage.setItem('trakttv.trending.cache', JSON.stringify(data))
         return true
+      },
+
+      /**
+       * Detect a stale-calendar profile where visible returning favorites have no
+       * future episodes and all known episodes already fell behind the current date window.
+       * In that case the startup `trakttv.lastupdated` gate may be newer than the actual DB.
+       */
+      needsRecoveryUpdate: function() {
+        return FavoritesService.waitForInitialization().then(function() {
+          var now = new Date().getTime()
+          var staleBefore = now - RECOVERY_LOOKBACK_MS
+          return CRUD.executeQuery(`
+            SELECT
+              SUM(CASE WHEN displaycalendar = 1 AND status = 'returning series' THEN 1 ELSE 0 END) AS visibleReturningCount,
+              SUM(CASE
+                WHEN displaycalendar = 1
+                  AND status = 'returning series'
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM Episodes
+                    WHERE Episodes.ID_Serie = Series.ID_Serie
+                      AND Episodes.seasonnumber > 0
+                      AND Episodes.firstaired >= ?
+                  )
+                  AND IFNULL((
+                    SELECT MAX(Episodes.firstaired)
+                    FROM Episodes
+                    WHERE Episodes.ID_Serie = Series.ID_Serie
+                      AND Episodes.seasonnumber > 0
+                  ), 0) < ?
+                THEN 1 ELSE 0
+              END) AS staleReturningCount
+            FROM Series
+          `, [now, staleBefore]).then(function(result) {
+            var row = result.rows.length > 0 ? result.rows.item(0) : { visibleReturningCount: 0, staleReturningCount: 0 }
+            var visibleReturningCount = +row.visibleReturningCount || 0
+            var staleReturningCount = +row.staleReturningCount || 0
+            return visibleReturningCount > 0 && staleReturningCount === visibleReturningCount
+          }, function(err) {
+            console.error('Unable to evaluate stale calendar recovery state.', err)
+            return false
+          })
+        })
       }
     }
 
@@ -90,11 +134,13 @@ DuckieTV.run(['TraktTVUpdateService', 'SettingsService',
     var updateFunc = function() {
       var localDateTime = new Date().getTime()
       var tuPeriod = parseInt(SettingsService.get('trakt-update.period')) // TraktTV Update period in hours.
+      var recoveryCooldownMs = 1000 * 60 * 60 * 24
       if (!localStorage.getItem('trakttv.lastupdated')) {
         localStorage.setItem('trakttv.lastupdated', localDateTime)
       }
 
       var lastUpdated = new Date(parseInt(localStorage.getItem('trakttv.lastupdated')))
+      var recoveryLastAttempt = parseInt(localStorage.getItem('trakttv.lastforcedupdate')) || 0
       if ((parseInt(localStorage.getItem('trakttv.lastupdated')) + (1000 * 60 * 60 * tuPeriod)) /* hours */ <= localDateTime) {
         TraktTVUpdateService.update(lastUpdated).then(function(count) {
           console.info('TraktTV update check completed. ' + count + ' shows updated since ' + lastUpdated)
@@ -102,6 +148,23 @@ DuckieTV.run(['TraktTVUpdateService', 'SettingsService',
         })
       } else {
         console.info('Not performing TraktTV update check. Already done within the last %s hour(s).', tuPeriod)
+        TraktTVUpdateService.needsRecoveryUpdate().then(function(needsRecoveryUpdate) {
+          if (!needsRecoveryUpdate) {
+            return
+          }
+
+          if (recoveryLastAttempt + recoveryCooldownMs > localDateTime) {
+            console.info('Skipping stale-calendar recovery update. Already attempted within the last 24 hour(s).')
+            return
+          }
+
+          console.info('Forcing TraktTV recovery update because visible returning favorites appear stale.')
+          localStorage.setItem('trakttv.lastforcedupdate', localDateTime)
+          TraktTVUpdateService.update(lastUpdated).then(function(count) {
+            console.info('TraktTV recovery update completed. ' + count + ' shows updated since ' + lastUpdated)
+            localStorage.setItem('trakttv.lastupdated', localDateTime)
+          })
+        })
       }
 
       if (!localStorage.getItem('trakttv.lastupdated.trending')) {


### PR DESCRIPTION
## Summary

This PR adds a recovery path for a stale-calendar startup state where DuckieTV skips Trakt refreshes because `localStorage['trakttv.lastupdated']` is recent, even though the local DB is already outdated.

In that state, favorites are still present and visible, but the calendar can appear empty because the local episode data is stuck in the past.

This PR is intended to address the issue reported in #1539.

## Problem

The existing startup logic only checks whether `trakttv.lastupdated + trakt-update.period <= now`.

If that gate says "already updated recently", DuckieTV skips the Trakt refresh pass entirely.

That is fine when the local DB is actually current, but it breaks down when:
- the local DB is stale,
- `trakttv.lastupdated` is still recent,
- the app restarts,
- the refresh is skipped,
- and the calendar remains stale indefinitely.

In the reproduced case, the local profile had no future episodes after **2026-03-02**, while Trakt already had newer schedule data for shows such as:
- `The Rookie`
- `Grey's Anatomy`
- `Tracker`
- `Fire Country`

## Fix

When the normal startup gate decides to skip the scheduled Trakt refresh, DuckieTV now performs a lightweight recovery check.

The recovery check looks for a very specific stale profile shape:
- visible favorites only (`displaycalendar = 1`)
- `status = 'returning series'`
- no future episodes for any visible returning favorite
- latest known aired episode for those shows is already older than a 7 day lookback window

If all visible returning favorites match that stale pattern, DuckieTV forces a recovery refresh from Trakt.

To avoid an overly aggressive startup behavior, the recovery refresh is rate-limited with a separate 24 hour cooldown using `localStorage['trakttv.lastforcedupdate']`.

## Why this approach

This keeps the existing scheduled refresh behavior intact for normal profiles and only adds a fallback when the calendar is clearly stuck behind the current date window.

The goal here is not to refresh more often in general, but to make sure a stale local profile can recover on its own instead of staying broken across restarts and upgrades.

## Validation

I validated the change in two ways:

1. Syntax check:
- `node --check js/services/TraktTVUpdateService.js`

2. Heuristic validation against real reproduced data:
- stale backup profile: `needsRecoveryUpdate = true`
- repaired live profile: `needsRecoveryUpdate = false`

In the reproduced stale profile, all visible returning favorites were behind the current date window and had no future episodes. In the repaired profile, upcoming episodes existed again, so the recovery path no longer matched.

## Notes

I did not run the full Karma test suite because the repo clone here does not include installed test dependencies.
