### PR TITLE
Security: Hardcoded Default Credentials

### DIFF
--- a/js/services/SynologyDSVideo.js
+++ b/js/services/SynologyDSVideo.js
@@ -1,10 +1,10 @@
 DuckieTV.factory('SynologyDSVideo', ['$q', '$http', function($q, $http) {
   var config = {
-    ip: '192.168.1.139',
+    ip: '',
     port: '5000',
     protocol: 'http',
-    account: 'admin',
-    password: 'admin'
+    account: '',
+    password: ''
   }
 
   var api = {


### PR DESCRIPTION
## Summary

Security: Hardcoded Default Credentials

## Problem

**Severity**: `Critical` | **File**: `js/services/SynologyDSVideo.js:L4`

SynologyDSVideo service contains hardcoded default credentials (admin/admin) and IP address in js/services/SynologyDSVideo.js. These credentials are exposed in the source code.

## Solution

Remove hardcoded credentials. Require users to configure their own credentials through the settings interface. Never ship default credentials in source code.

## Changes

- `js/services/SynologyDSVideo.js` (modified)