### PR TITLE
Fix qBittorrent 5.x login: accept HTTP 204 as successful auth

### DIFF
--- a/js/services/TorrentClients/qBittorrent41plus.js
+++ b/js/services/TorrentClients/qBittorrent41plus.js
@@ -3,6 +3,7 @@
  *
  * API Docs:
  * https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation v4.1+ APIv2 (appear to have been deleted)
+ * https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0) v5.0+ APIv2
  *
  */
 var qBittorrentData = function(data) {
@@ -77,7 +78,8 @@ DuckieTorrent.factory('qBittorrent41plusAPI', ['BaseHTTPApi', '$http', '$q',
             'X-Forwarded-Host': window.location.origin
           }
         }).then(function(result) {
-          if (result.data == 'Ok.') {
+          // qBittorrent < 5.0 returns 'Ok.' in the body; 5.0+ returns HTTP 204 with no body
+          if (result.data == 'Ok.' || result.status === 204) {
             if (window.debugTSE) console.debug('qBittorrent41plusAPI.login', result.data)
             return self.request('version').then(function(result) {
               var subs = result.data.split('.')


### PR DESCRIPTION
qBittorrent 5.0 changed the /api/v2/auth/login response from returning the string Ok. in the body (HTTP 200) to returning HTTP 204 with an empty body.
  
The login check in qBittorrent41plusAPI.login() only tested result.data == 'Ok.', so every login attempt against qBittorrent 5.x failed silently — DuckieTV showed "connect call failed"
despite the server being reachable and credentials being correct.

Fix: also accept result.status === 204 as a successful login.

Tested against: qBittorrent 5.2.0 (Flatpak), DuckieTV standalone in a Debian distrobox.
